### PR TITLE
Allow replacing of the PubSub engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.13.0",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.0",
     "typings": "^1.3.2"
   },
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { FilteredPubSub, SubscriptionManager } from './pubsub';
+export { PubSub, SubscriptionManager } from './pubsub';


### PR DESCRIPTION
* Moved filter functionality to the SubscriptionsManager.
* Added pubsub argument to SubscriptionManager to allow for different kinds of PubSub Engines
* Updated typescript dependencies to 2.0.0 to allow for the current graphql typings to work. see https://github.com/Microsoft/TypeScript/issues/7279