### PR TITLE
Support async subscribe method (or other PubSub engine methods)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
     "istanbul": "1.0.0-alpha.2",
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.13.0",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.0",
     "typings": "^1.3.2"
   },
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { FilteredPubSub, SubscriptionManager } from './pubsub';
+export { PubSub, SubscriptionManager } from './pubsub';

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1,7 +1,5 @@
-import {
-  assert,
-  expect,
-} from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 
 import {
   parse,
@@ -20,27 +18,33 @@ import {
 
 import { subscriptionHasSingleRootField } from '../validation';
 
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+const assert = chai.assert;
+
 describe('PubSub', function() {
   it('can subscribe and is called when events happen', function(done) {
     const ps = new PubSub();
     ps.subscribe('a', payload => {
       expect(payload).to.equals('test');
       done();
+    }).then(() => {
+      const succeed = ps.publish('a', 'test');
+      expect(succeed).to.be.true;
     });
-    const succeed = ps.publish('a', 'test');
-    expect(succeed).to.be.true;
   });
 
   it('can unsubscribe', function(done) {
     const ps = new PubSub();
-    const subId = ps.subscribe('a', payload => {
+    ps.subscribe('a', payload => {
       assert(false);
+    }).then((subId) => {
+      ps.unsubscribe(subId);
+      const succeed = ps.publish('a', 'test');
+      expect(succeed).to.be.true; // True because publish success is not
+                                  // indicated by trigger having subscriptions
+      done(); // works because pubsub is synchronous
     });
-    ps.unsubscribe(subId);
-    const succeed = ps.publish('a', 'test');
-    expect(succeed).to.be.true; // True because publish success is not
-                                // indicated by trigger having subscriptions
-    done(); // works because pubsub is synchronous
   });
 });
 
@@ -110,33 +114,31 @@ describe('SubscriptionManager', function() {
   it('throws an error if query is not valid', function() {
     const query = 'query a{ testInt }';
     const callback = () => null;
-    return expect(
-      () => subManager.subscribe({ query, operationName: 'a', callback })
-    ).to.throw('Error: Subscription query has validation errors');
+    return expect(subManager.subscribe({ query, operationName: 'a', callback }))
+        .to.eventually.be.rejectedWith('Subscription query has validation errors');
   });
 
   it('rejects subscriptions with more than one root field', function() {
     const query = 'subscription X{ a: testSubscription, b: testSubscription }';
     const callback = () => null;
-    return expect(
-      () => subManager.subscribe({ query, operationName: 'X', callback })
-    ).to.throw('Error: Subscription query has validation errors');
+    return expect(subManager.subscribe({ query, operationName: 'X', callback }))
+      .to.eventually.be.rejectedWith('Subscription query has validation errors');
   });
 
   it('requires operationName to be provided', function() {
     const query = 'subscription { testSubscription }';
     const callback = () => null;
-    return expect(
-      () => subManager.subscribe({ query, operationName: undefined as string, callback })
-    ).to.throw('Must provide operationName');
+    return expect(subManager.subscribe({ query, operationName: undefined as string, callback }))
+      .to.eventually.be.rejectedWith('Must provide operationName');
   });
 
   it('can subscribe with a valid query and gets a subId back', function() {
     const query = 'subscription X{ testSubscription }';
     const callback = () => null;
-    const subId = subManager.subscribe({ query, operationName: 'X', callback });
-    expect(subId).to.be.a('number');
-    subManager.unsubscribe(subId);
+    subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
+      expect(subId).to.be.a('number');
+      subManager.unsubscribe(subId);
+    });
   });
 
   it('can subscribe with a valid query and get the root value', function(done) {
@@ -150,9 +152,11 @@ describe('SubscriptionManager', function() {
       }
       done();
     };
-    const subId = subManager.subscribe({ query, operationName: 'X', callback });
-    subManager.publish('testSubscription', 'good');
-    subManager.unsubscribe(subId);
+
+    subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
+      subManager.publish('testSubscription', 'good');
+      subManager.unsubscribe(subId);
+    });
   });
 
   it('can use filter functions properly', function(done) {
@@ -168,15 +172,16 @@ describe('SubscriptionManager', function() {
       }
       done();
     };
-    const subId = subManager.subscribe({
+    subManager.subscribe({
       query,
       operationName: 'Filter1',
       variables: { filterBoolean: true},
       callback,
+    }).then(subId => {
+      subManager.publish('Filter1', {filterBoolean: false });
+      subManager.publish('Filter1', {filterBoolean: true });
+      subManager.unsubscribe(subId);
     });
-    subManager.publish('Filter1', {filterBoolean: false });
-    subManager.publish('Filter1', {filterBoolean: true });
-    subManager.unsubscribe(subId);
   });
 
   it('can subscribe to more than one trigger', function(done) {
@@ -199,16 +204,17 @@ describe('SubscriptionManager', function() {
         done();
       }
     };
-    const subId = subManager.subscribe({
+    subManager.subscribe({
       query,
       operationName: 'multiTrigger',
       variables: { filterBoolean: true, uga: 'UGA'},
       callback,
+    }).then(subId => {
+      subManager.publish('NotATrigger', {filterBoolean: false});
+      subManager.publish('Trigger1', {filterBoolean: true });
+      subManager.publish('Trigger2', {filterBoolean: true });
+      subManager.unsubscribe(subId);
     });
-    subManager.publish('NotATrigger', {filterBoolean: false});
-    subManager.publish('Trigger1', {filterBoolean: true });
-    subManager.publish('Trigger2', {filterBoolean: true });
-    subManager.unsubscribe(subId);
   });
 
   it('can unsubscribe', function(done) {
@@ -222,10 +228,11 @@ describe('SubscriptionManager', function() {
       }
       done();
     };
-    const subId = subManager.subscribe({ query, operationName: 'X', callback });
-    subManager.unsubscribe(subId);
-    subManager.publish('testSubscription', 'bad');
-    setTimeout(done, 30);
+    subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
+      subManager.unsubscribe(subId);
+      subManager.publish('testSubscription', 'bad');
+      setTimeout(done, 30);
+    });
   });
 
   it('throws an error when trying to unsubscribe from unknown id', function () {
@@ -249,9 +256,11 @@ describe('SubscriptionManager', function() {
       }
       done();
     };
-    const subId = subManager.subscribe({ query, operationName: 'X', callback });
-    subManager.publish('testSubscription', 'good');
-    subManager.unsubscribe(subId);
+
+    subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
+      subManager.publish('testSubscription', 'good');
+      subManager.unsubscribe(subId);
+    });
   });
 });
 

--- a/typings.json
+++ b/typings.json
@@ -6,6 +6,7 @@
     "node": "registry:dt/node#6.0.0+20160818175514"
   },
   "dependencies": {
-    "chai": "registry:npm/chai#3.5.0+20160723033700"
+    "chai": "registry:npm/chai#3.5.0+20160723033700",
+    "chai-as-promised": "registry:npm/chai-as-promised#5.1.0+20160310030142"
   }
 }


### PR DESCRIPTION
Hi @helfer,

This PR is to allow PubSub managers like redis pubsub or any other event source that cannot be run on the same process as the graphql-subscriptions process.

I've updated the tests and the EventEmitter based PubSubEngine to just Promise.resolve the given subscription id so it will behave the same as before.

Also wrote a redis PubSub Engine to go along with this PR - https://github.com/davidyaha/graphql-redis-subscriptions

Thanks ahead,
David