### PR TITLE
Update graphql.js dependency to 0.7.0 so there will not be duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "es6-promise": "^3.2.1",
-    "graphql": "^0.6.2"
+    "graphql": "^0.7.0"
   },
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
Basically whenever you try to run any codebase with graphql.js you got to have only one copy of it in the node_modules. Having multiple versions on related packages is causing definite problems as dedup is not possible..