### PR TITLE
Make filter function reflect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const subscriptionManager = new SubscriptionManager({
   // every time a new comment is posted whose repository name matches args.repoFullName.
   setupFunctions: {
     commentAdded: (options, args) => ({
-      newCommentsChannel: comment => comment.repository_name === args.repoFullName,
+      newCommentsChannel: comment => comment.repoFullName === args.repoName,
     }),
   },
 });


### PR DESCRIPTION
Correct me if I'm wrong, but it looks like the argument to comentAdded in the subscription (line 37) is called repoName, and in the example publish call (line 57), you give the comment the attribute repoFullName. I made the subscription filter function reflect this naming.