### PR TITLE
Pass SubscriptionOptions to PubSubEngine.subscribe

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -21,9 +21,19 @@ import {
     subscriptionHasSingleRootField
 } from './validation';
 
+export interface SubscriptionOptions {
+    query: string;
+    operationName: string;
+    callback: Function;
+    variables?: { [key: string]: any };
+    context?: any;
+    formatError?: Function;
+    formatResponse?: Function;
+};
+
 export interface PubSubEngine {
   publish(triggerName: string, payload: any): boolean
-  subscribe(triggerName: string, onMessage: Function): Promise<number>
+  subscribe(triggerName: string, onMessage: Function, options: SubscriptionOptions): Promise<number>
   unsubscribe(subId: number)
 }
 
@@ -69,16 +79,6 @@ export class ValidationError extends Error {
         this.message = 'Subscription query has validation errors';
     }
 }
-
-export interface SubscriptionOptions {
-    query: string;
-    operationName: string;
-    callback: Function;
-    variables?: { [key: string]: any };
-    context?: any;
-    formatError?: Function;
-    formatResponse?: Function;
-};
 
 // This manages actual GraphQL subscriptions.
 export class SubscriptionManager {
@@ -177,7 +177,7 @@ export class SubscriptionManager {
           const handler = (data) => shouldTrigger(data) && onMessage(data);
 
             // 3. subscribe and keep the subscription id
-            const subsPromise = this.pubsub.subscribe(triggerName, handler);
+            const subsPromise = this.pubsub.subscribe(triggerName, handler, options);
             subsPromise.then(id => this.subscriptions[externalSubscriptionId].push(id));
 
             subscriptionPromises.push(subsPromise);


### PR DESCRIPTION
See apollostack/graphql-subscriptions/issues/7

By passing the SubscriptionOptions to the PubSubEngine it can in turn create more specific subscriptions to sources such as RabbitMQ and rethinkDB.

For example, assume that we are interested in updates to a specific comment. We could listen to _all_ comment updates and use our filter function to only send the relevant updates to the client. However, this assumes that it's feasible to listen to all comment updates on our Apollo server in the first place.

By allowing PubSubEngine.subscribe access to SubscriptionOptions it could listen for exactly the subset of comment updates the client requested. For instance, by subscribing to the RabbitMQ channel `updates.comments.COMMENT_ID` as opposed to `updates.comments`.