### PR TITLE
Make a setupFunction return an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "istanbul": "^1.0.0-alpha.2",
     "mocha": "^3.0.0",
     "remap-istanbul": "^0.6.4",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0",
     "tslint": "^3.13.0",
     "typescript": "^2.0.0",
     "typings": "^1.3.2"

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -80,16 +80,33 @@ export interface SubscriptionOptions {
     formatResponse?: Function;
 };
 
+export interface TriggerConfig {
+    channelOptions?: Object;
+    filter?: Function;
+}
+
+export interface TriggerMap {
+    [triggerName: string]: TriggerConfig;
+}
+
+export interface SetupFunction {
+    (options: SubscriptionOptions, args: {[key: string]: any}, subscriptionName: string): TriggerMap;
+}
+
+export interface SetupFunctions {
+    [subscriptionName: string]: SetupFunction;
+}
+
 // This manages actual GraphQL subscriptions.
 export class SubscriptionManager {
     private pubsub: PubSubEngine;
     private schema: GraphQLSchema;
-    private setupFunctions: { [subscriptionName: string]: Function };
+    private setupFunctions: SetupFunctions;
     private subscriptions: { [externalId: number]: Array<number>};
     private maxSubscriptionId: number;
 
     constructor(options: {  schema: GraphQLSchema,
-                            setupFunctions: {[subscriptionName: string]: Function},
+                            setupFunctions: SetupFunctions,
                             pubsub: PubSubEngine }){
         this.pubsub = options.pubsub;
         this.schema = options.schema;
@@ -139,7 +156,7 @@ export class SubscriptionManager {
             }
         });
 
-        let triggerMap;
+        let triggerMap: TriggerMap;
 
         if (this.setupFunctions[subscriptionName]) {
             triggerMap = this.setupFunctions[subscriptionName](options, args, subscriptionName);

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -23,7 +23,7 @@ import {
 
 export interface PubSubEngine {
   publish(triggerName: string, payload: any): boolean
-  subscribe(triggerName: string, onMessage: Function): Promise<number>
+  subscribe(triggerName: string, onMessage: Function, options: Object): Promise<number>
   unsubscribe(subId: number)
 }
 
@@ -156,7 +156,11 @@ export class SubscriptionManager {
             const trigger = triggerMap[triggerName];
 
             // Deconstruct the trigger options and set any defaults
-            let {filter} = trigger;
+            let {channelOptions, filter} = trigger;
+
+            if (!channelOptions) {
+                channelOptions = {};
+            }
 
             if (typeof filter !== 'function') {
                 // Let all messages through by default.
@@ -188,7 +192,7 @@ export class SubscriptionManager {
             const handler = (data) => filter(data) && onMessage(data);
 
             // 3. subscribe and keep the subscription id
-            const subsPromise = this.pubsub.subscribe(triggerName, handler);
+            const subsPromise = this.pubsub.subscribe(triggerName, handler, channelOptions);
             subsPromise.then(id => this.subscriptions[externalSubscriptionId].push(id));
 
             subscriptionPromises.push(subsPromise);

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -170,11 +170,11 @@ export class SubscriptionManager {
                     // It's not a GraphQL error, so what do we do with it?
                     options.callback(e);
                 }
-            }
+            };
 
             // Will run the onMessage function only if the message passes the filter function.
-          const shouldTrigger: Function = triggerMap[triggerName];
-          const handler = (data) => shouldTrigger(data) && onMessage(data);
+            const shouldTrigger: Function = triggerMap[triggerName];
+            const handler = (data) => shouldTrigger(data) && onMessage(data);
 
             // 3. subscribe and keep the subscription id
             const subsPromise = this.pubsub.subscribe(triggerName, handler);

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -153,10 +153,8 @@ export class SubscriptionManager {
         this.subscriptions[externalSubscriptionId] = [];
         const subscriptionPromises = [];
         Object.keys(triggerMap).forEach( triggerName => {
-            const trigger = triggerMap[triggerName];
-
             // Deconstruct the trigger options and set any defaults
-            let {channelOptions, filter} = trigger;
+            let {channelOptions, filter} = triggerMap[triggerName];
 
             if (!channelOptions) {
                 channelOptions = {};

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -171,16 +171,10 @@ export class SubscriptionManager {
         const subscriptionPromises = [];
         Object.keys(triggerMap).forEach( triggerName => {
             // Deconstruct the trigger options and set any defaults
-            let {channelOptions, filter} = triggerMap[triggerName];
-
-            if (!channelOptions) {
-                channelOptions = {};
-            }
-
-            if (typeof filter !== 'function') {
-                // Let all messages through by default.
-                filter = () => true;
-            }
+            const {
+                channelOptions = {},
+                filter = () => true, // Let all messages through by default.
+            } = triggerMap[triggerName];
 
             // 2. generate the handler function
             const onMessage = rootValue => {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -97,7 +97,7 @@ const schema = new GraphQLSchema({
         resolve: function (root) {
           return root;
         },
-      }
+      },
     },
   }),
 });
@@ -118,10 +118,10 @@ describe('SubscriptionManager', function() {
       'testFilterMulti': (options) => {
         return {
           'Trigger1': {
-            filter: () => true
+            filter: () => true,
           },
           'Trigger2': {
-            filter: () => true
+            filter: () => true,
           },
         };
       },

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -99,13 +99,19 @@ describe('SubscriptionManager', function() {
     setupFunctions: {
       'testFilter': (options, { filterBoolean }) => {
         return {
-          'Filter1': (root) => root.filterBoolean === filterBoolean,
+          'Filter1': {
+            filter: (root) => root.filterBoolean === filterBoolean,
+          },
         };
       },
       'testFilterMulti': (options) => {
         return {
-          'Trigger1': () => true,
-          'Trigger2': () => true,
+          'Trigger1': {
+            filter: () => true
+          },
+          'Trigger2': {
+            filter: () => true
+          },
         };
       },
     },

--- a/typings.json
+++ b/typings.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "chai": "registry:npm/chai#3.5.0+20160723033700",
-    "chai-as-promised": "registry:npm/chai-as-promised#5.1.0+20160310030142"
+    "chai-as-promised": "registry:npm/chai-as-promised#5.1.0+20160310030142",
+    "sinon": "registry:npm/sinon#1.16.0+20160723033700",
+    "sinon-chai": "registry:npm/sinon-chai#2.8.0+20160310030142"
   }
 }


### PR DESCRIPTION
See #10 for previous communication. Solves #7. 

This change requires a setup function to return an object containing the properties `filter` and `channelOptions`. Both are optional, so no breaking changes in that regard. However, there is no backwards compatibility for the "old style" function-type return value, so existing usages need to be updated to return an object with `filter` property.

Code example taken from #10, adapted to object-style return value:
```javascript
{
    setupFunctions: {
        // Taken from GitHunt.
        commentAdded: (options, args) => ({
            commentAdded: {
                filter: comment => comment.repository_name === args.repoFullName
            }
        }),
        // Proposed structure.
        commentUpdated: (options, args) => ({
            commentUpdated: {
                // These options could be passed to PubSub.
                channelOptions: {
                    repoFullName: args.repoFullName
                },
                // Technically redundant since we specified repoFullName above and thus should
                // only receive relevant messages. However, it's here for completeness' sake
                filter: comment => comment.repository_name === args.repoFullName
            }
        })
    }
}
```

Note that I added a dev dependency to [sinon](https://www.npmjs.com/package/sinon) to be able to assert channelOptions are passed into `pubsub.subscribe`. 