### PR TITLE
Allow context to be a function that is called per message

### DIFF
--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -329,24 +329,22 @@ describe('SubscriptionManager', function() {
     });
   });
 
-  it('calls createContext if provided', function(done) {
+  it('calls context if it is a function', function(done) {
     const query = `subscription TestContext { testContext }`;
     const callback = function(error, payload) {
       expect(error).to.be.null;
       expect(payload.data.testContext).to.eq('trigger');
       done();
     };
-    const createContext = function(rootValue, options) {
-      expect(options.context).to.be.eq('original');
+    const context = function() {
       return 'trigger';
     };
     subManager.subscribe({
       query,
-      context: 'original',
+      context,
       operationName: 'TestContext',
       variables: {},
       callback,
-      createContext,
     }).then(subId => {
       subManager.publish('contextTrigger', 'ignored');
       subManager.unsubscribe(subId);


### PR DESCRIPTION
The idea behind this change is to support a distinct context for each processed message. The idea is to mirror the per HTTP request GraphQL context creation flow. Currently the context is fixed on the SubscriptionManager when the initial publish is created and is also used to create the triggerMap. The API change adds `createContext: Function` to SubscriptionOptions. If specified the new context is passed to `filter` and `onMessage`.