### PR TITLE
Added license & authors files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+Authors
+
+Jonas Helfer <helfer@users.noreply.github.com>
+Jonas Helfer <jonas@helfer.email>
+Quint Stoffers <quintstoffers@users.noreply.github.com>
+Sashko Stubailo <s.stubailo@gmail.com>
+Sashko Stubailo <sashko@stubailo.com>
+David Yahalomi <davidyaha@users.noreply.github.com>
+Alexander Anich <Anichale@users.noreply.github.com>
+Francois Valdy <gluck@users.noreply.github.com>
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 - 2016 Meteor Development Group, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/graphql-subscriptions.svg)](https://badge.fury.io/js/graphql-subscriptions) [![GitHub license](https://img.shields.io/github/license/apollostack/graphql-subscriptions.svg)](https://github.com/apollostack/graphql-subscriptions/blob/license/LICENSE)
+
 # graphql-subscriptions
 
 GraphQL subscriptions is a simple npm package that lets you wire up GraphQL with a pubsub system (like Redis) to implement subscriptions in GraphQL.


### PR DESCRIPTION
Updated README with license & npm badges on the way

(Assumed same state as apollostack/subscriptions-transport-ws#37)