### PR TITLE
Fix for https://github.com/apollostack/graphql-subscriptions/issues/2…

### DIFF
--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -182,6 +182,15 @@ describe('SubscriptionManager', function() {
     });
   });
 
+  it('can subscribe with a nameless query and gets a subId back', function() {
+    const query = 'subscription { testSubscription }';
+    const callback = () => null;
+    subManager.subscribe({ query, operationName: 'X', callback }).then(subId => {
+      expect(subId).to.be.a('number');
+      subManager.unsubscribe(subId);
+    });
+  });
+
   it('can subscribe with a valid query and get the root value', function(done) {
     const query = 'subscription X{ testSubscription }';
     const callback = function(err, payload){

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -19,7 +19,7 @@ export function subscriptionHasSingleRootField(context: ValidationContext): any 
   schema.getSubscriptionType();
   return {
     OperationDefinition(node) {
-      const operationName = node.name.value;
+      const operationName = node.name ? node.name.value : '';
       let numFields = 0;
       node.selectionSet.selections.forEach( (selection: Selection) => {
         if (selection.kind === FIELD) {


### PR DESCRIPTION
Nameless queries no longer error out. I added a quick test as well.