### PR TITLE
Fix the duplicate dependency for graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "es6-promise": "^3.2.1",
-    "graphql": "^0.7.0"
   },
   "scripts": {
     "compile": "tsc",
@@ -24,6 +23,7 @@
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info"
   },
   "devDependencies": {
+    "graphql": "^0.7.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "istanbul": "^1.0.0-alpha.2",


### PR DESCRIPTION
Move the graphql to devDependencies

Now graphql-subscriptions will not install an extra graphql when graphql release a new version 
graphql-subscriptions will resolve to what ever version the user is using.